### PR TITLE
Added From<> impl for internal hash value

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -102,6 +102,12 @@ macro_rules! create_fnvhasher {
                 FnvHashResult::[<from_u $x>](hash)
             }
         }
+
+        impl From<[<Fnv $x>]> for [<u $x>] {
+            fn from(value: [<Fnv $x>]) -> Self {
+                value.0
+            }
+        }
     }}
 }
 


### PR DESCRIPTION
Not sure if you're interested, but your library has been terribly useful for reverse engineering content from Cyberpunk 2077, which uses both 32 and 64 bit FNV1a hashes throughout its files. However I've needed access to the hashed value in memory without going through it being encoded as a byte array and back again, so I added support for the `From<>` trait for the native internal hash type